### PR TITLE
Update _helpers.tpl

### DIFF
--- a/charts/soketi/templates/_helpers.tpl
+++ b/charts/soketi/templates/_helpers.tpl
@@ -40,7 +40,6 @@ helm.sh/chart: {{ include "soketi.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app: soketi
 {{- end }}
 
 {{- define "soketi.bullExporterLabels" -}}


### PR DESCRIPTION
This chart is producing duplicated keys, which goes against the YAML standard.

Helm incorrectly ignores this, but using tooling like FluxCD this fails.

```
---
# Source: soketi/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: soketi
  labels:
    helm.sh/chart: soketi-0.15.3
    app.kubernetes.io/name: soketi
    app.kubernetes.io/instance: soketi
    app: soketi
    app.kubernetes.io/version: "0.29.0"
    app.kubernetes.io/managed-by: Helm
    app: soketi
```