### PR TITLE
ref: remove SERVER_PORT from network-watcher container

### DIFF
--- a/charts/soketi/templates/deployment.yaml
+++ b/charts/soketi/templates/deployment.yaml
@@ -72,8 +72,6 @@ spec:
           env:
             - name: KUBE_CONNECTION
               value: cluster
-            - name: SERVER_PORT
-              value: "{{ .Values.service.port }}"
             - name: MEMORY_PERCENT
               value: "{{ .Values.networkWatcher.threshold }}"
             - name: CHECKING_INTERVAL


### PR DESCRIPTION
This PR removes the `SERVER_PORT` env var from the `network-watcher` container since it is bound to the service port (set [here](https://github.com/soketi/charts/blob/a1b458991bda5221e968c04536852b419e06d21e/charts/soketi/templates/deployment.yaml#L116-L117)) instead of the metrics port for the current pod (assumed default of `9601`)