### PR TITLE
feat(soketi)!: Support k8s 1.25

### DIFF
--- a/charts/soketi/Chart.yaml
+++ b/charts/soketi/Chart.yaml
@@ -20,4 +20,4 @@ version: 2.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.5.0
+appVersion: 1.6.0

--- a/charts/soketi/Chart.yaml
+++ b/charts/soketi/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.4.0
+appVersion: 1.5.0

--- a/charts/soketi/README.md
+++ b/charts/soketi/README.md
@@ -25,7 +25,7 @@ Install the soketi chart:
 ```bash
 $ helm upgrade soketi \
     --install \
-    --version=1.0.2 \
+    --version=2.0.0 \
     soketi/soketi
 ```
 

--- a/charts/soketi/README.md
+++ b/charts/soketi/README.md
@@ -9,7 +9,7 @@ Containerize & Orchestrate your soketi application with this simple Helm chart.
 
 ## 🛑 Requirements
 
-- Kubernetes v1.19+
+- Kubernetes v1.23+
 
 ## 🚀 Installation
 

--- a/charts/soketi/templates/bullmq-pdb.yaml
+++ b/charts/soketi/templates/bullmq-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.bullExporter.enabled) (gt (.Values.bullExporter.replicaCount | int) 1) -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/soketi/templates/hpa.yaml
+++ b/charts/soketi/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "soketi.fullname" . }}

--- a/charts/soketi/templates/pdb.yaml
+++ b/charts/soketi/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (gt (.Values.replicaCount | int) 1) -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/soketi/values.yaml
+++ b/charts/soketi/values.yaml
@@ -19,10 +19,10 @@ app:
   image:
     repository: quay.io/soketi/soketi
     pullPolicy: IfNotPresent
-    tag: "1.5-16-debian"
+    tag: "1.6-16-debian"
     # You can use distroless to avoid Remote Code Execution attacks in-cluster.
     # https://github.com/soketi/soketi/pull/178
-    # tag: "1.5-16-distroless"
+    # tag: "1.6-16-distroless"
 
   # It's recommended to run the server with
   # maximum memory that would match the resource limits

--- a/charts/soketi/values.yaml
+++ b/charts/soketi/values.yaml
@@ -19,10 +19,10 @@ app:
   image:
     repository: quay.io/soketi/soketi
     pullPolicy: IfNotPresent
-    tag: "1.4-16-alpine"
+    tag: "1.5-16-alpine"
     # You can use distroless to avoid Remote Code Execution attacks in-cluster.
     # https://github.com/soketi/soketi/pull/178
-    # tag: "1.3-16-distroless"
+    # tag: "1.5-16-distroless"
 
   # It's recommended to run the server with
   # maximum memory that would match the resource limits

--- a/charts/soketi/values.yaml
+++ b/charts/soketi/values.yaml
@@ -19,7 +19,7 @@ app:
   image:
     repository: quay.io/soketi/soketi
     pullPolicy: IfNotPresent
-    tag: "1.5-16-alpine"
+    tag: "1.5-16-debian"
     # You can use distroless to avoid Remote Code Execution attacks in-cluster.
     # https://github.com/soketi/soketi/pull/178
     # tag: "1.5-16-distroless"


### PR DESCRIPTION
This PR adds support for k8s 1.25+ and drops support for k8s < 1.23. Additionally the default version of Soketi has been bumped to 1.5