### PR TITLE
feat: Add PDB API version override to support Kubernetes 1.25+

### DIFF
--- a/charts/k8soketi/templates/pdb.yaml
+++ b/charts/k8soketi/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (gt (.Values.replicaCount | int) 1) -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ .Values.pdb.apiVersion | default "policy/v1beta1" }}
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/k8soketi/values.yaml
+++ b/charts/k8soketi/values.yaml
@@ -153,7 +153,7 @@ autoscaling:
   #       averageValue: "50"
 
 pdb:
-  apiVersion: policy/v1beta1
+  apiVersion: policy/v1
   enabled: false
   minAvailable: 1
   # maxUnavailable: 25%

--- a/charts/k8soketi/values.yaml
+++ b/charts/k8soketi/values.yaml
@@ -153,6 +153,7 @@ autoscaling:
   #       averageValue: "50"
 
 pdb:
+  apiVersion: policy/v1beta1
   enabled: false
   minAvailable: 1
   # maxUnavailable: 25%


### PR DESCRIPTION
Makes the Pod Disruption Budget API version configurable in the k8soketi Helm chart and defaults to the stable `policy/v1` API.

## Changes
- **Template**: Modified `pdb.yaml` template to use `{{ .Values.pdb.apiVersion | default "policy/v1beta1" }}` instead of hardcoded `policy/v1beta1`
- **Values**: Added `pdb.apiVersion: policy/v1` to use the stable API by default

## Background  
The `policy/v1beta1` API for PodDisruptionBudget was:
- Deprecated in Kubernetes 1.21
- Removed in Kubernetes 1.25

## Benefits
- ✅ **Forward compatible**: Defaults to stable `policy/v1` API
- ✅ **Backward compatible**: Allows override to `policy/v1beta1` for older clusters  
- ✅ **Configurable**: Users can set any API version via values
- ✅ **Safe upgrade path**: Existing deployments continue working with fallback default

## Testing
- Verified template renders correctly with both API versions
- Maintains existing functionality while supporting modern Kubernetes clusters